### PR TITLE
Fixes #45 - Expose website URL in backgroundScript

### DIFF
--- a/app/lib/communication/PortHost.js
+++ b/app/lib/communication/PortHost.js
@@ -15,15 +15,25 @@ export default class PortHost extends EventEmitter {
     _registerListeners() {
         chrome.extension.onConnect.addListener(port => {
             let source = port.name;
+            let hostname = false;
 
             if(port.sender.tab && source !== 'popup')
                 source += `-${port.sender.tab.id}`;
+
+            if(port.sender.url)
+                hostname = new URL(port.sender.url).hostname;
 
             this._ports[source] = port;
             logger.info(`Port ${source} connected`);
 
             port.onMessage.addListener(({ action, data }, sendingPort) => {
-                this.emit(action, { source, data });
+                this.emit(action, { 
+                    meta: {
+                        hostname
+                    },
+                    source, 
+                    data
+                });
             });
 
             port.onDisconnect.addListener(() => {

--- a/app/lib/consts.js
+++ b/app/lib/consts.js
@@ -1,3 +1,0 @@
-export const CONFIRMATION_TYPE = {
-    SEND : "SEND"
-};

--- a/app/lib/messages/LinkedResponse.js
+++ b/app/lib/messages/LinkedResponse.js
@@ -12,12 +12,12 @@ export default class LinkedResponse extends EventEmitter {
     }
 
     _registerListener() {
-        this._eventHandler.on('tunnel', ({ source, data: { uuid, data } }) => {
-            this._respond(source, uuid, data);
+        this._eventHandler.on('tunnel', ({ source, meta, data: { uuid, data } }) => {
+            this._respond(source, uuid, data, meta);
         });
     }
 
-    _respond(source, uuid, request) {
+    _respond(source, uuid, request, meta) {
         const response = {            
             resolve: data => {
                 this._eventHandler.send(source, 'tunnel', { 
@@ -33,7 +33,8 @@ export default class LinkedResponse extends EventEmitter {
                     error
                 });
             },
-            request
+            request,
+            meta
         };
 
         this.emit('request', response);

--- a/app/pageHook/api/v1/index.js
+++ b/app/pageHook/api/v1/index.js
@@ -61,7 +61,7 @@ class TronLink {
     }
 
     _transformAddress(address) {
-        if(Object.prototype.toString.call(address) !== '[object String]')
+        if(!Utils.isString(address))
             return false;
 
         switch(address.length) {
@@ -110,6 +110,9 @@ class TronLink {
                 return this._dispatch('getLatestBlock', { transactionID });
             },
             getAccount: address => {
+                if(!this.utils.validateAddress(address))
+                    throw new Error('Invalid address provided');
+
                 return this._dispatch('getLatestBlock', { address });
             }
         };
@@ -117,11 +120,29 @@ class TronLink {
 
     get wallet() {
         return {
-            sendTron: (recipient, amount) => {
-                return this._dispatch('sendTron', { recipient, amount });
+            sendTron: (recipient, amount, desc = false) => {
+                if(!this.utils.validateAddress(recipient))
+                    throw new Error('Invalid recipient provided');
+
+                if(!Utils.validateAmount(amount))
+                    throw new Error('Invalid amount provided');
+
+                if(!Utils.validateDescription(desc))
+                    throw new Error('Invalid description provided');
+                
+                return this._dispatch('sendTron', { recipient, amount, desc });
             },
-            sendAsset: (recipient, amount, assetID) => {
-                return this._dispatch('sendAsset', { recipient, amount, assetID });
+            sendAsset: (recipient, amount, assetID, desc) => {
+                if(!this.utils.validateAddress(recipient))
+                    throw new Error('Invalid recipient provided');
+
+                if(!Utils.validateAmount(amount))
+                    throw new Error('Invalid amount provided');
+
+                if(!Utils.validateDescription(desc))
+                    throw new Error('Invalid description provided');
+
+                return this._dispatch('sendAsset', { recipient, amount, assetID, desc });
             },
             sendTransaction: transaction => {
                 return this._dispatch('sendTransaction', { transaction });
@@ -130,6 +151,9 @@ class TronLink {
                 return this._dispatch('signTransaction', { transaction });
             },
             simulateSmartContract: (address, data) => {
+                if(!this.utils.validateAddress(address))
+                    throw new Error('Invalid smart contract address provided');
+
                 return this._dispatch('simulateSmartContract', { address, data });
             },
             getAccount: () => {

--- a/app/pageHook/lib/Utils.js
+++ b/app/pageHook/lib/Utils.js
@@ -54,6 +54,27 @@ const Utils = {
 
             return temp;
         }).join('');
+    },
+    isString(string) {
+        return Object.prototype.toString.call(string) === '[object String]';
+    },
+    isNumber(number) {
+        return !isNaN(parseFloat(number)) && isFinite(number);
+    },
+    validateDescription(desc) {
+        if(desc && !this.isString(desc))
+            return false;
+
+        if(desc && desc.length > 240)
+            return false;
+
+        if(desc && !desc.length)
+            return false;
+
+        return true;
+    },
+    validateAmount(amount) {
+        return this.isNumber(amount) && amount > 0;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "TronUtils": "Flott-org/TronUtils",
+    "TronUtils": "https://github.com/Flott-org/TronUtils",
     "babel-loader": "^7.1.5",
     "babel-minify-webpack-plugin": "^0.3.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-TronUtils@Flott-org/TronUtils:
+"TronUtils@https://github.com/Flott-org/TronUtils":
   version "1.0.0"
-  resolved "https://codeload.github.com/Flott-org/TronUtils/tar.gz/1236e67909a13df8b64369df256bf82390a4a2eb"
+  resolved "https://github.com/Flott-org/TronUtils#1236e67909a13df8b64369df256bf82390a4a2eb"
   dependencies:
     assert "^1.4.1"
     axios "^0.18.0"


### PR DESCRIPTION
This exposes `hostname`, `desc` and `recipient` fields in the confirmation object. `desc` is optional with a maximum of 240 characters.

I've also removed an unused file and added some validation to the API calls.

@metjm I suggest validating the `recipient` field in backgroundScript. I've done so in `pageHook` too but due to how we implement the network selection differently our validation functions will differ slightly.