### PR TITLE
"Force" popup to open in top left of the browser

### DIFF
--- a/app/backgroundScript/index.js
+++ b/app/backgroundScript/index.js
@@ -65,7 +65,16 @@ const addConfirmation = (confirmation, resolve, reject) => {
         dialog = window.open(
             'app/popup/build/index.html',
             'extension_popup',
-            'width=436,height=634,status=no,scrollbars=no,centerscreen=yes,alwaysRaised=yes'
+            [
+                'width=436',
+                'height=634',
+                'status=no',
+                'scrollbars=no',
+                'centerscreen=yes',
+                'alwaysRaised=yes',
+                'top=25',
+                'left=25'
+            ].join(',')
         );
     });
 };


### PR DESCRIPTION
For some reason some operating system configurations don't open the popup in the top left. Whilst we cannot open it perfectly (i.e. if window isn't maximized), we can do the best possible to make sure it opens in the top left.

Similar issue with MetaMask. No current workaround.