### PR TITLE
1.1.4: Queue client-side requests

### DIFF
--- a/app/pageHook/ExtensionProvider.js
+++ b/app/pageHook/ExtensionProvider.js
@@ -1,11 +1,62 @@
 import TronWeb from 'tronweb';
+import Logger from 'lib/logger';
+import axios from 'axios';
+
+const logger = new Logger('ExtensionProvider');
 
 const {
     HttpProvider
 } = TronWeb.providers;
 
 export default class ExtensionProvider extends HttpProvider {
+    constructor(...args) {
+        super(...args);
+
+        this.ready = false;
+        this.queue = [];
+
+        logger.info('Provider initiated');
+    }
+
+    setURL(url) {
+        logger.info('Received new host:', url);
+
+        this.instance = axios.create({
+            baseURL: url,
+            timeout: 30000
+        });
+
+        this.ready = true;
+
+        while(this.queue.length) {
+            const {
+                args,
+                resolve,
+                reject
+            } = this.queue.shift();
+
+            this.request(...args)
+                .then(resolve)
+                .catch(reject)
+                .then(() => (
+                    logger.info(`Request to ${ args[0] } completed`)
+                ));
+        }
+    }
+
     request(url, payload = {}, method = 'get') {
+        if(!this.ready) {
+            logger.info(`Request to ${ url } has been queued`);
+
+            return new Promise((resolve, reject) => {
+                this.queue.push({
+                    args: [ url, payload, method ],
+                    resolve,
+                    reject
+                });
+            });
+        }
+
         return super.request(url, payload, method).then(res => {
             // Some transaction calls have a nested transaction property
             const obj = res.hasOwnProperty('transaction') ? res.transaction : res;

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "TronLink",
-    "version": "1.1.3",
-    "version_name": "1.1.3",
+    "version": "1.1.4",
+    "version_name": "1.1.4",
     "description": "An interactive chrome extension for signing, receiving and broadcasting TRON transactions",
     "author": "https://github.com/TronWatch",
 	"icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronlink",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "private": false,
     "dependencies": {
         "aes-js": "^3.1.1",


### PR DESCRIPTION
A timing error can occur when a website servers a node with a request before the nodes have been configured after dispatching the appropriate events. To combat this issue I've created a queue - one for the full node, one for the solidity node, and one for the event server.

As soon as the nodes are connected they will process each request in the queue.