### PR TITLE
Remove source map from build

### DIFF
--- a/fixBuild.js
+++ b/fixBuild.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/fixBuild.js
+++ b/fixBuild.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const fileLocation = path.join(__dirname, 'dist', 'pageHook.js');
+const build = fs.readFileSync(fileLocation, 'utf8');
+const fixed = build
+    .replace('if (isInBrowser())', 'if(1 == 2)')
+    .replace('retrieveFile(source)', '\'\'');
+
+fs.writeFileSync(fileLocation, fixed);

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "TronLink",
-    "version": "1.2.1",
-    "version_name": "1.2.1",
+    "version": "1.2.2",
+    "version_name": "1.2.2",
     "description": "An interactive browser extension for signing, receiving and broadcasting TRON transactions",
     "author": "https://github.com/TronWatch",
 	"icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronlink",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "private": false,
     "dependencies": {
         "aes-js": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "build:react": "cd app/popup && npm run build && cd ../../",
         "build:all": "npm run build && npm run build:react",
         "test:react": "cd app/popup && npm run test && cd ../../",
-        "zip": "npm run build:all && npx bestzip chrome-extension.zip dist static manifest.json app/popup/build",
+        "zip": "npm run build:all && node fixBuild && npx bestzip chrome-extension.zip dist static manifest.json app/popup/build",
         "symlink:win": "mklink /D app\\popup\\src\\extension ..\\..\\lib",
         "symlink": "cd app/popup/src && ln -s ../../lib extension && cd ../../../"
     },

--- a/package.json
+++ b/package.json
@@ -87,11 +87,10 @@
         "lint-staged": "lint-staged",
         "lint": "./node_modules/.bin/eslint .",
         "clean": "rimraf dist",
-        "build": "npm run clean && webpack --config webpack.config.js --progress --colors",
+        "build": "npm run clean && webpack --config webpack.config.js --progress --colors && node fixBuild",
         "build:react": "cd app/popup && npm run build && cd ../../",
         "build:all": "npm run build && npm run build:react",
-        "test:react": "cd app/popup && npm run test && cd ../../",
-        "zip": "npm run build:all && node fixBuild && npx bestzip chrome-extension.zip dist static manifest.json app/popup/build",
+        "zip": "npm run build:all && npx bestzip chrome-extension.zip dist static manifest.json app/popup/build",
         "symlink:win": "mklink /D app\\popup\\src\\extension ..\\..\\lib",
         "symlink": "cd app/popup/src && ln -s ../../lib extension && cd ../../../"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ module.exports = function(env) {
             filename: '[name].js',
             sourceMapFilename: '[name].js.map'
         },
-        devtool: 'source-map',
         module: {
             loaders: [
                 {


### PR DESCRIPTION
This fixes an odd bug which was preventing some sites (either Angular or sites that include an iframe) from working. We could never pin down the specific issue, although it only occurred on sites that met the above criteria.

TronLink 2.0 will be being releasing soon - this is just a fix for anybody running 1.x.