### PR TITLE
TRC10 duplicate name support

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.12",
+  "version": "2.0.13",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "TronLink",
-    "version": "2.0.12",
-    "version_name": "2.0.12",
+    "version": "2.0.13",
+    "version_name": "2.0.13",
     "description": "An interactive browser extension for signing, receiving and broadcasting TRON transactions",
     "author": "Kondax <kondaxsolutions@gmail.com>",
     "content_security_policy": "script-src 'self' 'unsafe-eval' 'sha256-LayQc1iWBC+6WbHHvHZj3uSx3CxrGBHUJBR7si4qf8w=' 'sha256-POEO+wER89cezFVZ27JoP523HJNPMQxmh5Rcz/OZpr4=' 'sha256-IThiKMnsg0UHaLmP7sJxZpd/ohvINImwjxFJyxGFSlk=' https://*.sentry.io https://www.google-analytics.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; object-src 'self'",

--- a/packages/backgroundScript/package.json
+++ b/packages/backgroundScript/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/TronLink/TronLink",
   "author": "Kondax <kondaxsolutions@gmail.com>",
   "private": true,
-  "version": "2.0.12",
+  "version": "2.0.13",
   "dependencies": {
     "@sentry/browser": "^4.3.4",
     "axios": "^0.18.0",

--- a/packages/backgroundScript/package.json
+++ b/packages/backgroundScript/package.json
@@ -12,7 +12,7 @@
     "bip39": "^2.5.0",
     "buffer": "^5.2.1",
     "eventemitter3": "^3.1.0",
-    "tronweb": "^2.1.17"
+    "tronweb": "^2.1.25"
   },
   "scripts": {
     "build": "webpack --config ../../webpack.config.js --progress --colors -o ../../dist/backgroundScript.js",

--- a/packages/backgroundScript/services/WalletService/Account.js
+++ b/packages/backgroundScript/services/WalletService/Account.js
@@ -230,7 +230,7 @@ class Account {
                         const {
                             name,
                             abbr,
-                            decimals = 0
+                            precision: decimals = 0
                         } = await NodeService.tronWeb.trx.getTokenFromID(key);
 
                         token = {

--- a/packages/backgroundScript/services/WalletService/Account.js
+++ b/packages/backgroundScript/services/WalletService/Account.js
@@ -136,6 +136,9 @@ class Account {
             lastUpdated
         } = StorageService.getAccount(this.address);
 
+        // Old TRC10 structure are no longer compatible
+        tokens.basic = {};
+
         this.type = type;
         this.name = name;
         this.balance = balance;
@@ -195,9 +198,7 @@ class Account {
             this.tokens.smart[ address ].balance = 0
         ));
 
-        Object.keys(this.tokens.basic).forEach(token => (
-            this.tokens.basic[ token ] = 0
-        ));
+        this.tokens.basic = {};
     }
 
     async update() {

--- a/packages/backgroundScript/services/WalletService/index.js
+++ b/packages/backgroundScript/services/WalletService/index.js
@@ -122,10 +122,6 @@ class Wallet extends EventEmitter {
         this.isPolling = true;
         const accounts = Object.values(this.accounts);
 
-        // We could show a loading indicator for each
-        // individual account, and publish updates accordingly
-        // instead of in bulk
-
         for(const account of accounts) {
             await account.update();
 

--- a/packages/contentScript/package.json
+++ b/packages/contentScript/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "extensionizer": "^1.0.1",
-    "tronweb": "^2.1.17"
+    "tronweb": "^2.1.25"
   }
 }

--- a/packages/contentScript/package.json
+++ b/packages/contentScript/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/TronLink/TronLink",
   "author": "Kondax <kondaxsolutions@gmail.com>",
   "private": true,
-  "version": "2.0.12",
+  "version": "2.0.13",
   "scripts": {
     "build": "webpack --config ../../webpack.config.js --progress --colors -o ../../dist/contentScript.js",
     "lint": "npx eslint . --fix"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/TronLink/TronLink",
   "author": "Kondax <kondaxsolutions@gmail.com>",
   "private": true,
-  "version": "2.0.12",
+  "version": "2.0.13",
   "dependencies": {
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "dateformat": "^3.0.3",
     "eventemitter3": "^3.1.0",
     "extensionizer": "^1.0.1",
-    "tronweb": "^2.1.17",
+    "tronweb": "^2.1.25",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/packages/pageHook/package.json
+++ b/packages/pageHook/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/TronLink/TronLink",
   "author": "Kondax <kondaxsolutions@gmail.com>",
   "private": true,
-  "version": "2.0.12",
+  "version": "2.0.13",
   "scripts": {
     "build": "webpack --config ../../webpack.config.js --progress --colors -o ../../dist/pageHook.js",
     "lint": "npx eslint . --fix"

--- a/packages/pageHook/package.json
+++ b/packages/pageHook/package.json
@@ -10,6 +10,6 @@
     "lint": "npx eslint . --fix"
   },
   "dependencies": {
-    "tronweb": "^2.1.17"
+    "tronweb": "^2.1.25"
   }
 }

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -27,7 +27,7 @@
     "redux-starter-kit": "^0.2.0",
     "sweetalert2": "^7.29.2",
     "sweetalert2-react-content": "^1.0.1",
-    "tronweb": "^2.1.17"
+    "tronweb": "^2.1.25"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -3,7 +3,7 @@
   "main": "index.js",
   "repository": "https://github.com/TronLink/TronLink",
   "author": "Kondax <kondaxsolutions@gmail.com>",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.8",

--- a/packages/popup/src/pages/SendPage/index.js
+++ b/packages/popup/src/pages/SendPage/index.js
@@ -91,15 +91,26 @@ class SendPage extends React.Component {
     onTokenChange({ value: token }) {
         const { mode } = this.state.token;
 
-        if(mode === TOKEN_MODE.TRC10)
-            return this.setState({ token: { mode, name: token } });
+        const {
+            basic,
+            smart
+        } = this.props.tokens;
 
-        const { decimals } = this.props.tokens.smart[ token ];
+        if(mode === TOKEN_MODE.TRC10) {
+            return this.setState({
+                token: {
+                    tokenID: token,
+                    decimals: basic [ token ].decimals,
+                    name: basic[ token ].name,
+                    mode
+                }
+            });
+        }
 
         this.setState({
             token: {
                 address: token,
-                decimals,
+                decimals: smart[ token ].decimals,
                 mode
             }
         }, () => this.validateAmount());
@@ -121,8 +132,11 @@ class SendPage extends React.Component {
         if(mode === TOKEN_MODE.TRC20 && !Object.keys(smart).length)
             return;
 
-        if(mode === TOKEN_MODE.TRC10)
-            token.name = Object.keys(basic)[ 0 ];
+        if(mode === TOKEN_MODE.TRC10) {
+            token.tokenID = Object.keys(basic)[ 0 ];
+            token.decimals = basic [ token.tokenID ].decimals;
+            token.name = basic[ token.tokenID ].name;
+        }
 
         if(mode === TOKEN_MODE.TRC20) {
             token.address = Object.keys(smart)[ 0 ];
@@ -137,8 +151,9 @@ class SendPage extends React.Component {
     validateAmount() {
         const {
             mode,
-            name,
-            address
+            tokenID,
+            address,
+            decimals
         } = this.state.token;
 
         const {
@@ -170,14 +185,18 @@ class SendPage extends React.Component {
         if(mode === TOKEN_MODE.TRX)
             balance = new BigNumber(this.props.account.balance).shiftedBy(-6);
 
-        if(mode === TOKEN_MODE.TRC10)
-            balance = new BigNumber(basic[ name ]);
+        if(mode === TOKEN_MODE.TRC10) {
+            const token = basic[ tokenID ];
+
+            balance = new BigNumber(token.balance)
+                .shiftedBy(decimals);
+        }
 
         if(mode === TOKEN_MODE.TRC20) {
             const token = smart[ address ];
 
             balance = new BigNumber(token.balance)
-                .shiftedBy(-token.decimals);
+                .shiftedBy(-decimals);
         }
 
         this.setState({
@@ -201,7 +220,7 @@ class SendPage extends React.Component {
 
         const {
             mode,
-            name,
+            tokenID,
             address,
             decimals
         } = this.state.token;
@@ -215,8 +234,13 @@ class SendPage extends React.Component {
             );
         }
 
-        if(mode === TOKEN_MODE.TRC10)
-            func = PopupAPI.sendBasicToken(recipient, amount, name);
+        if(mode === TOKEN_MODE.TRC10) {
+            func = PopupAPI.sendBasicToken(
+                recipient,
+                new BigNumber(amount).shiftedBy(decimals).toString(),
+                tokenID
+            );
+        }
 
         if(mode === TOKEN_MODE.TRC20) {
             func = PopupAPI.sendSmartToken(
@@ -271,23 +295,28 @@ class SendPage extends React.Component {
 
     renderBasicDropdown() {
         const { basic } = this.props.tokens;
-        const { name } = this.state.token;
         const { formatNumber } = this.props.intl;
         const { isLoading } = this.state;
 
-        const options = Object.entries(basic).map(([ token, balance ]) => ({
-            value: token,
-            label: `${ token } (${ formatNumber(balance) })`
+        const {
+            tokenID,
+            name,
+            decimals
+        } = this.state.token;
+
+        const options = Object.entries(basic).map(([ tokenID, token ]) => ({
+            value: tokenID,
+            label: `${ token.name } (${ formatNumber(new BigNumber(token.balance).shiftedBy(-token.decimals)) })`
         }));
 
-        if(!basic[ name ]) {
+        if(!basic[ tokenID ]) {
             this.reset();
             return null;
         }
 
         const selected = {
-            value: name,
-            label: `${ name } (${ formatNumber(basic[ name ]) })`
+            value: tokenID,
+            label: `${ name } (${ formatNumber(new BigNumber(basic[ tokenID ].balance).shiftedBy(-decimals)) })`
         };
 
         return (
@@ -339,8 +368,6 @@ class SendPage extends React.Component {
         const { mode } = this.state.token;
         const { value } = this.state.amount;
         const { isLoading } = this.state;
-
-        // Move the tabs into their own component
 
         return (
             <div className='tokens'>

--- a/packages/popup/src/pages/TokensPage/index.js
+++ b/packages/popup/src/pages/TokensPage/index.js
@@ -144,22 +144,33 @@ class TokensPage extends React.Component {
                     )}
                     />
                     <div className='tokenGroup basicTokens'>
-                        { Object.entries(basic).map(([ tokenName, amount ]) => (
-                            <div className='token basicToken' key={ tokenName }>
-                                <FormattedNumber
-                                    value={ amount }
-                                    maximumFractionDigits={ 0 }
-                                    children={ amount => (
-                                        <span className='tokenAmount mono'>
-                                            { amount }
-                                        </span>
-                                    )}
-                                />
-                                <span className='tokenSymbol'>
-                                    { tokenName }
-                                </span>
-                            </div>
-                        )) }
+                        { Object.entries(basic).map(([ tokenID, token ]) => {
+                            const BN = BigNumber.clone({
+                                DECIMAL_PLACES: token.decimals,
+                                ROUNDING_MODE: Math.min(8, token.decimals)
+                            });
+
+                            const amount = new BN(token.balance)
+                                .shiftedBy(-token.decimals)
+                                .toString();
+
+                            return (
+                                <div className='token basicToken' key={ tokenID }>
+                                    <FormattedNumber
+                                        value={ amount }
+                                        maximumFractionDigits={ 0 }
+                                        children={ amount => (
+                                            <span className='tokenAmount mono'>
+                                                { amount }
+                                            </span>
+                                        )}
+                                    />
+                                    <span className='tokenSymbol'>
+                                        { token.name }
+                                    </span>
+                                </div>
+                            );
+                        }) }
                     </div>
                 </CustomScroll>
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12222,10 +12222,10 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tronweb@^2.1.17:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/tronweb/-/tronweb-2.1.17.tgz#b4822e06674574cec82ce0c28aeb45a463c265b9"
-  integrity sha512-VdIDWoU9L1IpiXeWWMfPbERD3YW5JXyH5cS/Cx2lcMWrPV5Bq+Vk03SzwZUnY1tfrip1UhEGfy0TCdVmy9Tcug==
+tronweb@^2.1.25:
+  version "2.1.25"
+  resolved "https://registry.yarnpkg.com/tronweb/-/tronweb-2.1.25.tgz#bcfacec9b34106597b995eca9598d2f01eed5eb5"
+  integrity sha512-oVBmFw5IoOOPIEi0dJ0i3LoJCcFfbFkM/vbg8XgD6DYqfi6jkg34OMNAeKykn43Qc6AimQMjIO/OCeWNVQ0h3w==
   dependencies:
     "@babel/runtime" "^7.0.0"
     axios "^0.18.0"


### PR DESCRIPTION
This PR enables support for TRC10 duplicate names. This should not be merged or distributed until:

~~1. The HTTP API adds support for precision in `wallet/getassetissuebyname`~~
~~2. The duplicate name proposal is accepted on Mainnet~~

~~The only current issue is that the API is missing TRC10 token precision, meaning we can't know if one token is actually equated to `1` or `1000`, etc. For now it assumes there there is a `decimals` property, and if not it falls back to `0`.~~

~~It's entirely possible the API does have this parameter but doesn't include it for a token with no precision. I don't have the documentation for this, so somebody else might need to support me here.~~

Currently missing:
~~1. Assigning the correct precision~~
~~2. The transaction list, as the Shasta tx history endpoint is down~~

**Ready to be reviewed and merged**